### PR TITLE
Upgrade to latest ruby & alpine (& git) versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ language: ruby
 rvm:
   - 2.2.5
   - 2.3.1
+  - 2.5.0
 
 services:
   - docker

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4-alpine
+FROM ruby:2.4-alpine3.7
 
 RUN apk add --no-cache git build-base
 


### PR DESCRIPTION
Alpine 3.4 has an old (2.8) version of git.

Resolves: FARM-1522
Change-Id: Id5b1a4293fa6ea659fe46d097493810fca67c00e